### PR TITLE
Make the labels float

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,8 +51,8 @@ if __name__ == '__main__':
     optimizerG = optim.Adam(netG.parameters(), lr=opt.g_lr)
     
     # initialize other variables
-    real_label = 1
-    fake_label = 0
+    real_label = 1.
+    fake_label = 0.
     num_batches = len(train_loader)
     fixed_noise = torch.randn(opt.num_test_samples, 100, 1, 1, device=device)
 


### PR DESCRIPTION
Running the code fails with 

Traceback (most recent call last):
  File "main.py", line 72, in <module>
    lossD_real = criterion(output, label)
  File "/usr/local/lib/python3.6/dist-packages/torch/nn/modules/module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/torch/nn/modules/loss.py", line 530, in forward
    return F.binary_cross_entropy(input, target, weight=self.weight, reduction=self.reduction)
  File "/usr/local/lib/python3.6/dist-packages/torch/nn/functional.py", line 2526, in binary_cross_entropy
    input, target, weight, reduction_enum)
RuntimeError: Found dtype Long but expected Float


 It seems binary_cross_entropy (on pytorch 1.7.0 expects FloatTensor not LongTensor. Make the real_label and fake_label float solves the problem.